### PR TITLE
Fix 404 in logs

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -17,7 +17,7 @@ async function createBranch(branchName, git) {
 }
 
 async function clone(token, remote, dir, git) {
-  core.info(`Cloning ${remote}.`);
+  core.info(`Cloning ${remote}`);
   const remoteWithToken = getAuthanticatedUrl(token, remote);
   await git.clone(remoteWithToken, dir, {'--depth': 1});
   await git.addRemote(REMOTE, remoteWithToken);


### PR DESCRIPTION
Currently this message is in the logs:
```
Started updating xyz repo
  Cloning https://github.com/Vendic/xyz.
```

If you click on `https://github.com/Vendic/xyz.` it will result in a 404 because of the dot that's included in the url.