### PR TITLE
fix: use strict regex for default branch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8010,7 +8010,7 @@ async function createBranch(branchName, git) {
 }
 
 async function clone(token, remote, dir, git) {
-  core.info(`Cloning ${remote}.`);
+  core.info(`Cloning ${remote}`);
   const remoteWithToken = getAuthanticatedUrl(token, remote);
   await git.clone(remoteWithToken, dir, {'--depth': 1});
   await git.addRemote(REMOTE, remoteWithToken);
@@ -8039,6 +8039,7 @@ async function areFilesChanged(git) {
   return status.files.length > 0;
 }
   
+
 
 /***/ }),
 
@@ -15740,7 +15741,7 @@ async function getBranchesList(octokit, owner, repo, branchesString, defaultBran
 function filterOutMissingBranches(branchesRequested, branchesExisting, defaultBranch) {
   const branchesArray = branchesRequested
     ? parseCommaList(branchesRequested)
-    : [defaultBranch];
+    : [`^${defaultBranch}$`];
 
   core.info(`These were requested branches: ${branchesRequested}`);
   core.info(`This is default branch: ${defaultBranch}`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -222,7 +222,7 @@ async function getBranchesList(octokit, owner, repo, branchesString, defaultBran
 function filterOutMissingBranches(branchesRequested, branchesExisting, defaultBranch) {
   const branchesArray = branchesRequested
     ? parseCommaList(branchesRequested)
-    : [defaultBranch];
+    : [`^${defaultBranch}$`];
 
   core.info(`These were requested branches: ${branchesRequested}`);
   core.info(`This is default branch: ${defaultBranch}`);

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -196,6 +196,15 @@ describe('filterOutMissingBranches', () => {
       },
       {
         name: 'next'
+      },
+      {
+        name: 'not-main-branch'
+      },
+      {
+        name: 'main-not-i-am'
+      },
+      {
+        name: 'i-am-not-main'
       }
     ];
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

When targeting the default branch, the action matches any branch that contains the name of the branch.

I noticed once it had created `bot/manual-update-global-workflow-bot/update-global-workflow-bot/manual-update-global-workflow-main-682z1c-f9d96be555d6c90b389ed89c3de7038c325182ea-3psjvl` 😂 

I added some examples with `main` in various parts of branch names to the "should return default branch if others not requested" test for `filterOutMissingBranches`.

The current behaviour can still be achieved with `branches: main` once this is merged. Maybe that should be changed as well, i'm not sure.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->