### PR TITLE
feat: add support for custom branch name created by bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ exclude_private | Boolean value on whether to exclude private repositories from 
 exclude_forked | Boolean value on whether to exclude forked repositories from this action. | false | false
 branches | By default, action creates branch from default branch and opens PR only against default branch. With this property you can override this behaviour. You can provide a comma-separated list of branches this action shoudl work against. You can also provide regex, but without comma as list of branches is split in code by comma. | false | default branch is used
 destination | Name of the directory where all files matching "patterns_to_include" will be copied. It doesn't work with "patterns_to_remove". In the format `.github/workflows`. | false | -
+bot_branch_name | Use it if you do not want this action to create a new branch and new pull request with every run. By default branch names are generated. This means every single change is a separate commit. Such a static hardcoded branch name has an advantage that if you make a lot of changes, instead of having 5 PRs merged with 5 commits, you get one PR that is updated with new changes as long as the PR is not yet merged. If you use static name, and by mistake someone closed a PR, without merging and removing branch, this action will not fail but update the branch and open a new PR. Example value that you could provide: `bot_branch_name: bot/update-files-from-global-repo` | false | -
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,10 @@ inputs:
     description: >
       Name of the directory where all files matching "patterns_to_include" will be copied. It doesn't work with "patterns_to_remove". In the format `.github/workflows`.
     required: false
+  bot_branch_name:
+    description: >
+      Use it if you do not want this action to create a new branch and new pull request with every run. By default branch names are generated. This means every single change is a separate commit. Such a static hardcoded branch name has an advantage that if you make a lot of changes, instead of having 5 PRs merged with 5 commits, you get one PR that is updated with new changes as long as the PR is not yet merged. If you use static name, and by mistake someone closed a PR, without merging and removing branch, this action will not fail but update the branch and open a new PR. Example value that you could provide: `bot_branch_name: bot/update-files-from-global-repo`.
+    required: false
 runs:
   using: node16
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -8039,7 +8039,8 @@ async function push(branchName, message, committerUsername, committerEmail, git)
       await git.pull(['--rebase', REMOTE, branchName]);
     } catch (error) {
       core.info('Not able to pull:', error);
-      await git.merge(['--strategy-option=ours', branchName]);
+      await git.merge(['-X', 'ours', branchName]);
+      await git.add('./*');
       await git.push(['-u', REMOTE, branchName]);
     }
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -8032,9 +8032,18 @@ async function push(branchName, message, committerUsername, committerEmail, git)
   await git.addConfig('user.name', committerUsername);
   await git.addConfig('user.email', committerEmail);
   await git.commit(message);
-  await git.pull(REMOTE, branchName);
-  await git.merge();
-  await git.push(['-u', REMOTE, branchName]);
+  try {
+    await git.push(['-u', REMOTE, branchName]);
+  } catch (error) {
+    core.info('Not able to push:', error);
+    try {
+      await git.pull(REMOTE, branchName);
+    } catch (error) {
+      core.info('Not able to pull:', error);
+      await git.merge(['--strategy-option=ours', branchName]);
+      await git.push(['-u', REMOTE, branchName]);
+    }
+  }
 }
 
 async function areFilesChanged(git) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -8036,7 +8036,7 @@ async function push(branchName, message, committerUsername, committerEmail, git)
   } catch (error) {
     core.info('Not able to push:', error);
     try {
-      await git.pull(REMOTE, branchName);
+      await git.pull(['--rebase', REMOTE, branchName]);
     } catch (error) {
       core.info('Not able to pull:', error);
       await git.merge(['--strategy-option=ours', branchName]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -8032,7 +8032,8 @@ async function push(branchName, message, committerUsername, committerEmail, git)
   await git.addConfig('user.name', committerUsername);
   await git.addConfig('user.email', committerEmail);
   await git.commit(message);
-  await git.pull(['--rebase', REMOTE, branchName]);
+  await git.pull(REMOTE, branchName);
+  await git.merge();
   await git.push(['-u', REMOTE, branchName]);
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -8028,11 +8028,11 @@ async function getBranchesLocal(git) {
 async function push(branchName, message, committerUsername, committerEmail, git) {
   if (core.isDebug()) __webpack_require__(231).enable('simple-git');
   core.info('Pushing changes to remote');
-  
+  await git.fetch(REMOTE, branchName);
   await git.addConfig('user.name', committerUsername);
   await git.addConfig('user.email', committerEmail);
   await git.commit(message);
-  await git.push(['-u', REMOTE, branchName]);
+  await git.push(['-u', '--force', REMOTE, branchName]);
 }
 
 async function areFilesChanged(git) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -8035,16 +8035,20 @@ async function push(branchName, message, committerUsername, committerEmail, git)
     await git.push(['-u', REMOTE, branchName]);
   } catch (error) {
     core.info('Not able to push:', error);
+    core.debug('DEBUG: Git status after push issues');
+    core.debug(JSON.stringify(await git.status(), null, 2));
     try {
+      await git.pull([REMOTE, branchName]);
+    } catch (error) {
+      core.info('Not able to pull:', error);
+      core.debug('DEBUG: Git status after pull issues');
+      core.debug(JSON.stringify(await git.status(), null, 2));
       await git.merge(['-X', 'ours', branchName]);
+      core.debug('DEBUG: Git status after merge');
+      core.debug(JSON.stringify(await git.status(), null, 2));
       await git.add('./*');
       await git.commit(message);
-      const status = await git.status();
-      core.debug('DEBUG: List of differences spotted in the repository after merge conflicts');
-      core.debug(JSON.stringify(status, null, 2));
       await git.push(['-u', REMOTE, branchName]);
-    } catch (error) {
-      core.info('Not able to push:', error);
     }
   }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -8032,7 +8032,8 @@ async function push(branchName, message, committerUsername, committerEmail, git)
   await git.addConfig('user.name', committerUsername);
   await git.addConfig('user.email', committerEmail);
   await git.commit(message);
-  await git.push(['-u', '--force-with-lease', REMOTE, branchName]);
+  await git.pull(['--rebase', REMOTE, branchName]);
+  await git.push(['-u', REMOTE, branchName]);
 }
 
 async function areFilesChanged(git) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -8032,7 +8032,7 @@ async function push(branchName, message, committerUsername, committerEmail, git)
   await git.addConfig('user.name', committerUsername);
   await git.addConfig('user.email', committerEmail);
   await git.commit(message);
-  await git.push(['-u', '--force', REMOTE, branchName]);
+  await git.push(['-u', '--force-with-lease', REMOTE, branchName]);
 }
 
 async function areFilesChanged(git) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -14374,7 +14374,7 @@ async function run() {
           /*
            * 4a. Creating folder where repo will be cloned and initializing git client
            */
-          const dir = path.join(process.cwd(), './clones', repo.name);
+          const dir = path.join(process.cwd(), './clones', `${repo.name  }-${ Math.random().toString(36).substring(7)}`);
           await mkdir(dir, {recursive: true});
           const git = simpleGit({baseDir: dir});
 
@@ -14433,8 +14433,9 @@ async function run() {
                * 4fe. Opening a PR
                */
               const wasBranchThereAlready = branchesToOperateOn.some(branch => branch.name === newBranchName);
+              core.debug(`DEBUG: was branch ${newBranchName} there already in the repository? - ${wasBranchThereAlready}`);
+              core.debug(JSON.stringify(branchesToOperateOn, null, 2));
               let pullRequestUrl;
-              
               if (!wasBranchThereAlready) pullRequestUrl = await createPr(myOctokit, newBranchName, repo.id, commitMessage, branchName);
                     
               core.endGroup();

--- a/dist/index.js
+++ b/dist/index.js
@@ -8028,7 +8028,6 @@ async function getBranchesLocal(git) {
 async function push(branchName, message, committerUsername, committerEmail, git) {
   if (core.isDebug()) __webpack_require__(231).enable('simple-git');
   core.info('Pushing changes to remote');
-  await git.fetch(REMOTE, branchName);
   await git.addConfig('user.name', committerUsername);
   await git.addConfig('user.email', committerEmail);
   await git.commit(message);

--- a/dist/index.js
+++ b/dist/index.js
@@ -14299,6 +14299,7 @@ async function run() {
     const commitMessage = core.getInput('commit_message');
     const branches = core.getInput('branches');
     const destination = core.getInput('destination');
+    const customBranchName = core.getInput('bot_branch_name');
     const repoNameManual = eventPayload.inputs && eventPayload.inputs.repo_name;
 
     const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
@@ -14409,7 +14410,7 @@ async function run() {
             /*
              * 4db. Creating new branch in cloned repo
              */
-            const newBranchName = getBranchName(commitId, branchName);
+            const newBranchName = customBranchName || getBranchName(commitId, branchName);
             await createBranch(newBranchName, git);
 
             /*

--- a/dist/index.js
+++ b/dist/index.js
@@ -8036,12 +8036,11 @@ async function push(branchName, message, committerUsername, committerEmail, git)
   } catch (error) {
     core.info('Not able to push:', error);
     try {
-      await git.pull(['--rebase', REMOTE, branchName]);
-    } catch (error) {
-      core.info('Not able to pull:', error);
       await git.merge(['-X', 'ours', branchName]);
       await git.add('./*');
       await git.push(['-u', REMOTE, branchName]);
+    } catch (error) {
+      core.info('Not able to push:', error);
     }
   }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -14392,7 +14392,7 @@ async function run() {
            *     Should it be just default one or the ones provided by the user
            */
           const branchesToOperateOn = await getBranchesList(myOctokit, owner, repo.name, branches, defaultBranch); 
-          if (!branchesToOperateOn.length) {
+          if (!branchesToOperateOn[0].length) {
             core.info('Repo has no branches that the action could operate on');
             continue;
           }
@@ -14400,7 +14400,7 @@ async function run() {
           /*
            * 4d. Per branch operation starts
            */
-          for (const branch of branchesToOperateOn) {
+          for (const branch of branchesToOperateOn[0]) {
             /*
              * 4da. Checkout branch in cloned repo
              */
@@ -14432,7 +14432,7 @@ async function run() {
               /*
                * 4fe. Opening a PR
                */
-              const wasBranchThereAlready = branchesToOperateOn.some(branch => branch.name === newBranchName);
+              const wasBranchThereAlready = branchesToOperateOn[1].some(branch => branch.name === newBranchName);
               core.debug(`DEBUG: was branch ${newBranchName} there already in the repository? - ${wasBranchThereAlready}`);
               core.debug(JSON.stringify(branchesToOperateOn, null, 2));
               let pullRequestUrl;
@@ -15813,7 +15813,7 @@ function getBranchName(commitId, branchName) {
  * @param  {String} repo repo name
  * @param  {String} branchesString comma-separated list of branches
  * @param  {String} defaultBranch name of the repo default branch
- * @returns  {String}
+ * @returns  {Array<Object, Object>} first index is object with branches that user wants to operate on and that are in remote, next index has all remote branches
  */
 async function getBranchesList(octokit, owner, repo, branchesString, defaultBranch) {
   core.info('Getting list of branches the action should operate on');
@@ -15825,7 +15825,7 @@ async function getBranchesList(octokit, owner, repo, branchesString, defaultBran
 
   core.info(`These is a final list of branches action will operate on: ${JSON.stringify(filteredBranches, null, 2)}`);
 
-  return filteredBranches;
+  return [ filteredBranches, branchesFromRemote];
 }
 
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -14452,6 +14452,7 @@ async function run() {
                     
               /*
                * 4fe. Opening a PR. Doing in try/catch as it is not always failing because of timeouts, maybe branch already has a PR
+               * we need to try to create a PR cause there can be branch but someone closed PR, so branch is there but PR not
                */
               let pullRequestUrl;
               try {

--- a/dist/index.js
+++ b/dist/index.js
@@ -8038,6 +8038,10 @@ async function push(branchName, message, committerUsername, committerEmail, git)
     try {
       await git.merge(['-X', 'ours', branchName]);
       await git.add('./*');
+      await git.commit(message);
+      const status = await git.status();
+      core.debug('DEBUG: List of differences spotted in the repository after merge conflicts');
+      core.debug(JSON.stringify(status, null, 2));
       await git.push(['-u', REMOTE, branchName]);
     } catch (error) {
       core.info('Not able to push:', error);

--- a/dist/index.js
+++ b/dist/index.js
@@ -14431,13 +14431,18 @@ async function run() {
                     
               /*
                * 4fe. Opening a PR
-               */  
-              const pullRequestUrl = await createPr(myOctokit, newBranchName, repo.id, commitMessage, branchName);
+               */
+              const wasBranchThereAlready = branchesToOperateOn.some(branch => branch.name === newBranchName);
+              let pullRequestUrl;
+              
+              if (!wasBranchThereAlready) pullRequestUrl = await createPr(myOctokit, newBranchName, repo.id, commitMessage, branchName);
                     
               core.endGroup();
           
-              if (pullRequestUrl) {
+              if (pullRequestUrl && !wasBranchThereAlready) {
                 core.info(`Workflow finished with success and PR for ${repo.name} is created -> ${pullRequestUrl}`);
+              } else if (wasBranchThereAlready) {
+                core.info(`Workflow finished without PR creation for ${repo.name}. Insted push was performed to existing ${newBranchName} branch`);
               } else {
                 core.info(`Unable to create a PR because of timeouts. Create PR manually from the branch ${newBranchName} that was already created in the upstream`);
               }

--- a/lib/git.js
+++ b/lib/git.js
@@ -37,16 +37,20 @@ async function push(branchName, message, committerUsername, committerEmail, git)
     await git.push(['-u', REMOTE, branchName]);
   } catch (error) {
     core.info('Not able to push:', error);
+    core.debug('DEBUG: Git status after push issues');
+    core.debug(JSON.stringify(await git.status(), null, 2));
     try {
+      await git.pull([REMOTE, branchName]);
+    } catch (error) {
+      core.info('Not able to pull:', error);
+      core.debug('DEBUG: Git status after pull issues');
+      core.debug(JSON.stringify(await git.status(), null, 2));
       await git.merge(['-X', 'ours', branchName]);
+      core.debug('DEBUG: Git status after merge');
+      core.debug(JSON.stringify(await git.status(), null, 2));
       await git.add('./*');
       await git.commit(message);
-      const status = await git.status();
-      core.debug('DEBUG: List of differences spotted in the repository after merge conflicts');
-      core.debug(JSON.stringify(status, null, 2));
       await git.push(['-u', REMOTE, branchName]);
-    } catch (error) {
-      core.info('Not able to push:', error);
     }
   }
 }

--- a/lib/git.js
+++ b/lib/git.js
@@ -40,6 +40,10 @@ async function push(branchName, message, committerUsername, committerEmail, git)
     try {
       await git.merge(['-X', 'ours', branchName]);
       await git.add('./*');
+      await git.commit(message);
+      const status = await git.status();
+      core.debug('DEBUG: List of differences spotted in the repository after merge conflicts');
+      core.debug(JSON.stringify(status, null, 2));
       await git.push(['-u', REMOTE, branchName]);
     } catch (error) {
       core.info('Not able to push:', error);

--- a/lib/git.js
+++ b/lib/git.js
@@ -37,14 +37,10 @@ async function push(branchName, message, committerUsername, committerEmail, git)
     await git.push(['-u', REMOTE, branchName]);
   } catch (error) {
     core.info('Not able to push:', error);
-    core.debug('DEBUG: Git status after push issues');
-    core.debug(JSON.stringify(await git.status(), null, 2));
     try {
       await git.pull([REMOTE, branchName]);
     } catch (error) {
       core.info('Not able to pull:', error);
-      core.debug('DEBUG: Git status after pull issues');
-      core.debug(JSON.stringify(await git.status(), null, 2));
       await git.merge(['-X', 'ours', branchName]);
       core.debug('DEBUG: Git status after merge');
       core.debug(JSON.stringify(await git.status(), null, 2));

--- a/lib/git.js
+++ b/lib/git.js
@@ -38,7 +38,7 @@ async function push(branchName, message, committerUsername, committerEmail, git)
   } catch (error) {
     core.info('Not able to push:', error);
     try {
-      await git.pull(REMOTE, branchName);
+      await git.pull(['--rebase', REMOTE, branchName]);
     } catch (error) {
       core.info('Not able to pull:', error);
       await git.merge(['--strategy-option=ours', branchName]);

--- a/lib/git.js
+++ b/lib/git.js
@@ -34,7 +34,8 @@ async function push(branchName, message, committerUsername, committerEmail, git)
   await git.addConfig('user.name', committerUsername);
   await git.addConfig('user.email', committerEmail);
   await git.commit(message);
-  await git.pull(['--rebase', REMOTE, branchName]);
+  await git.pull(REMOTE, branchName);
+  await git.merge();
   await git.push(['-u', REMOTE, branchName]);
 }
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -30,11 +30,11 @@ async function getBranchesLocal(git) {
 async function push(branchName, message, committerUsername, committerEmail, git) {
   if (core.isDebug()) require('debug').enable('simple-git');
   core.info('Pushing changes to remote');
-  
+  await git.fetch(REMOTE, branchName);
   await git.addConfig('user.name', committerUsername);
   await git.addConfig('user.email', committerEmail);
   await git.commit(message);
-  await git.push(['-u', REMOTE, branchName]);
+  await git.push(['-u', '--force', REMOTE, branchName]);
 }
 
 async function areFilesChanged(git) {

--- a/lib/git.js
+++ b/lib/git.js
@@ -38,12 +38,11 @@ async function push(branchName, message, committerUsername, committerEmail, git)
   } catch (error) {
     core.info('Not able to push:', error);
     try {
-      await git.pull(['--rebase', REMOTE, branchName]);
-    } catch (error) {
-      core.info('Not able to pull:', error);
       await git.merge(['-X', 'ours', branchName]);
       await git.add('./*');
       await git.push(['-u', REMOTE, branchName]);
+    } catch (error) {
+      core.info('Not able to push:', error);
     }
   }
 }

--- a/lib/git.js
+++ b/lib/git.js
@@ -34,9 +34,18 @@ async function push(branchName, message, committerUsername, committerEmail, git)
   await git.addConfig('user.name', committerUsername);
   await git.addConfig('user.email', committerEmail);
   await git.commit(message);
-  await git.pull(REMOTE, branchName);
-  await git.merge();
-  await git.push(['-u', REMOTE, branchName]);
+  try {
+    await git.push(['-u', REMOTE, branchName]);
+  } catch (error) {
+    core.info('Not able to push:', error);
+    try {
+      await git.pull(REMOTE, branchName);
+    } catch (error) {
+      core.info('Not able to pull:', error);
+      await git.merge(['--strategy-option=ours', branchName]);
+      await git.push(['-u', REMOTE, branchName]);
+    }
+  }
 }
 
 async function areFilesChanged(git) {

--- a/lib/git.js
+++ b/lib/git.js
@@ -34,7 +34,7 @@ async function push(branchName, message, committerUsername, committerEmail, git)
   await git.addConfig('user.name', committerUsername);
   await git.addConfig('user.email', committerEmail);
   await git.commit(message);
-  await git.push(['-u', '--force', REMOTE, branchName]);
+  await git.push(['-u', '--force-with-lease', REMOTE, branchName]);
 }
 
 async function areFilesChanged(git) {

--- a/lib/git.js
+++ b/lib/git.js
@@ -34,7 +34,8 @@ async function push(branchName, message, committerUsername, committerEmail, git)
   await git.addConfig('user.name', committerUsername);
   await git.addConfig('user.email', committerEmail);
   await git.commit(message);
-  await git.push(['-u', '--force-with-lease', REMOTE, branchName]);
+  await git.pull(['--rebase', REMOTE, branchName]);
+  await git.push(['-u', REMOTE, branchName]);
 }
 
 async function areFilesChanged(git) {

--- a/lib/git.js
+++ b/lib/git.js
@@ -30,7 +30,6 @@ async function getBranchesLocal(git) {
 async function push(branchName, message, committerUsername, committerEmail, git) {
   if (core.isDebug()) require('debug').enable('simple-git');
   core.info('Pushing changes to remote');
-  await git.fetch(REMOTE, branchName);
   await git.addConfig('user.name', committerUsername);
   await git.addConfig('user.email', committerEmail);
   await git.commit(message);

--- a/lib/git.js
+++ b/lib/git.js
@@ -41,7 +41,8 @@ async function push(branchName, message, committerUsername, committerEmail, git)
       await git.pull(['--rebase', REMOTE, branchName]);
     } catch (error) {
       core.info('Not able to pull:', error);
-      await git.merge(['--strategy-option=ours', branchName]);
+      await git.merge(['-X', 'ours', branchName]);
+      await git.add('./*');
       await git.push(['-u', REMOTE, branchName]);
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -130,7 +130,7 @@ async function run() {
            *     Should it be just default one or the ones provided by the user
            */
           const branchesToOperateOn = await getBranchesList(myOctokit, owner, repo.name, branches, defaultBranch); 
-          if (!branchesToOperateOn.length) {
+          if (!branchesToOperateOn[0].length) {
             core.info('Repo has no branches that the action could operate on');
             continue;
           }
@@ -138,7 +138,7 @@ async function run() {
           /*
            * 4d. Per branch operation starts
            */
-          for (const branch of branchesToOperateOn) {
+          for (const branch of branchesToOperateOn[0]) {
             /*
              * 4da. Checkout branch in cloned repo
              */
@@ -170,7 +170,7 @@ async function run() {
               /*
                * 4fe. Opening a PR
                */
-              const wasBranchThereAlready = branchesToOperateOn.some(branch => branch.name === newBranchName);
+              const wasBranchThereAlready = branchesToOperateOn[1].some(branch => branch.name === newBranchName);
               core.debug(`DEBUG: was branch ${newBranchName} there already in the repository? - ${wasBranchThereAlready}`);
               core.debug(JSON.stringify(branchesToOperateOn, null, 2));
               let pullRequestUrl;

--- a/lib/index.js
+++ b/lib/index.js
@@ -169,13 +169,18 @@ async function run() {
                     
               /*
                * 4fe. Opening a PR
-               */  
-              const pullRequestUrl = await createPr(myOctokit, newBranchName, repo.id, commitMessage, branchName);
+               */
+              const wasBranchThereAlready = branchesToOperateOn.some(branch => branch.name === newBranchName);
+              let pullRequestUrl;
+              
+              if (!wasBranchThereAlready) pullRequestUrl = await createPr(myOctokit, newBranchName, repo.id, commitMessage, branchName);
                     
               core.endGroup();
           
-              if (pullRequestUrl) {
+              if (pullRequestUrl && !wasBranchThereAlready) {
                 core.info(`Workflow finished with success and PR for ${repo.name} is created -> ${pullRequestUrl}`);
+              } else if (wasBranchThereAlready) {
+                core.info(`Workflow finished without PR creation for ${repo.name}. Insted push was performed to existing ${newBranchName} branch`);
               } else {
                 core.info(`Unable to create a PR because of timeouts. Create PR manually from the branch ${newBranchName} that was already created in the upstream`);
               }

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,8 +149,15 @@ async function run() {
              * 4db. Creating new branch in cloned repo
              */
             const newBranchName = customBranchName || getBranchName(commitId, branchName);
-            await createBranch(newBranchName, git);
-
+            const wasBranchThereAlready = branchesToOperateOn[1].some(branch => branch.name === newBranchName);
+            core.debug(`DEBUG: was branch ${newBranchName} there already in the repository? - ${wasBranchThereAlready}`);
+            core.debug(JSON.stringify(branchesToOperateOn, null, 2));
+            if (wasBranchThereAlready) {
+              await checkoutBranch(newBranchName, git);
+            } else {
+              await createBranch(newBranchName, git);
+            }
+            
             /*
              * 4dc. Files replication/update or deletion
              * it is pretty clear that if there is nothing to replicate, then there definitely is something to remove
@@ -168,11 +175,8 @@ async function run() {
               await push(newBranchName, commitMessage, committerUsername, committerEmail, git);
                     
               /*
-               * 4fe. Opening a PR
+               * 4fe. Opening a PR only if needed and there is no branch in place already
                */
-              const wasBranchThereAlready = branchesToOperateOn[1].some(branch => branch.name === newBranchName);
-              core.debug(`DEBUG: was branch ${newBranchName} there already in the repository? - ${wasBranchThereAlready}`);
-              core.debug(JSON.stringify(branchesToOperateOn, null, 2));
               let pullRequestUrl;
               if (!wasBranchThereAlready) pullRequestUrl = await createPr(myOctokit, newBranchName, repo.id, commitMessage, branchName);
                     

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,7 +112,7 @@ async function run() {
           /*
            * 4a. Creating folder where repo will be cloned and initializing git client
            */
-          const dir = path.join(process.cwd(), './clones', repo.name);
+          const dir = path.join(process.cwd(), './clones', `${repo.name  }-${ Math.random().toString(36).substring(7)}`);
           await mkdir(dir, {recursive: true});
           const git = simpleGit({baseDir: dir});
 
@@ -171,8 +171,9 @@ async function run() {
                * 4fe. Opening a PR
                */
               const wasBranchThereAlready = branchesToOperateOn.some(branch => branch.name === newBranchName);
+              core.debug(`DEBUG: was branch ${newBranchName} there already in the repository? - ${wasBranchThereAlready}`);
+              core.debug(JSON.stringify(branchesToOperateOn, null, 2));
               let pullRequestUrl;
-              
               if (!wasBranchThereAlready) pullRequestUrl = await createPr(myOctokit, newBranchName, repo.id, commitMessage, branchName);
                     
               core.endGroup();

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ async function run() {
     const commitMessage = core.getInput('commit_message');
     const branches = core.getInput('branches');
     const destination = core.getInput('destination');
+    const customBranchName = core.getInput('bot_branch_name');
     const repoNameManual = eventPayload.inputs && eventPayload.inputs.repo_name;
 
     const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
@@ -147,7 +148,7 @@ async function run() {
             /*
              * 4db. Creating new branch in cloned repo
              */
-            const newBranchName = getBranchName(commitId, branchName);
+            const newBranchName = customBranchName || getBranchName(commitId, branchName);
             await createBranch(newBranchName, git);
 
             /*

--- a/lib/index.js
+++ b/lib/index.js
@@ -176,6 +176,7 @@ async function run() {
                     
               /*
                * 4fe. Opening a PR. Doing in try/catch as it is not always failing because of timeouts, maybe branch already has a PR
+               * we need to try to create a PR cause there can be branch but someone closed PR, so branch is there but PR not
                */
               let pullRequestUrl;
               try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -157,7 +157,7 @@ async function run() {
             } else {
               await createBranch(newBranchName, git);
             }
-            
+
             /*
              * 4dc. Files replication/update or deletion
              * it is pretty clear that if there is nothing to replicate, then there definitely is something to remove
@@ -175,16 +175,21 @@ async function run() {
               await push(newBranchName, commitMessage, committerUsername, committerEmail, git);
                     
               /*
-               * 4fe. Opening a PR only if needed and there is no branch in place already
+               * 4fe. Opening a PR. Doing in try/catch as it is not always failing because of timeouts, maybe branch already has a PR
                */
               let pullRequestUrl;
-              if (!wasBranchThereAlready) pullRequestUrl = await createPr(myOctokit, newBranchName, repo.id, commitMessage, branchName);
-                    
+              try {
+                pullRequestUrl = await createPr(myOctokit, newBranchName, repo.id, commitMessage, branchName);
+              } catch (error) {
+                if (wasBranchThereAlready)
+                  core.info(`PR creation for ${repo.name} failed as the branch was there already. Insted only push was performed to existing ${newBranchName} branch`, error);
+              }
+
               core.endGroup();
           
-              if (pullRequestUrl && !wasBranchThereAlready) {
+              if (pullRequestUrl) {
                 core.info(`Workflow finished with success and PR for ${repo.name} is created -> ${pullRequestUrl}`);
-              } else if (wasBranchThereAlready) {
+              } else if (!pullRequestUrl && wasBranchThereAlready) {
                 core.info(`Workflow finished without PR creation for ${repo.name}. Insted push was performed to existing ${newBranchName} branch`);
               } else {
                 core.info(`Unable to create a PR because of timeouts. Create PR manually from the branch ${newBranchName} that was already created in the upstream`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -259,7 +259,7 @@ function getBranchName(commitId, branchName) {
  * @param  {String} repo repo name
  * @param  {String} branchesString comma-separated list of branches
  * @param  {String} defaultBranch name of the repo default branch
- * @returns  {String}
+ * @returns  {Array<Object, Object>} first index is object with branches that user wants to operate on and that are in remote, next index has all remote branches
  */
 async function getBranchesList(octokit, owner, repo, branchesString, defaultBranch) {
   core.info('Getting list of branches the action should operate on');
@@ -271,7 +271,7 @@ async function getBranchesList(octokit, owner, repo, branchesString, defaultBran
 
   core.info(`These is a final list of branches action will operate on: ${JSON.stringify(filteredBranches, null, 2)}`);
 
-  return filteredBranches;
+  return [ filteredBranches, branchesFromRemote];
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -269,9 +269,9 @@ async function getBranchesList(octokit, owner, repo, branchesString, defaultBran
   //branches not available an remote will not be included
   const filteredBranches = filterOutMissingBranches(branchesString, branchesFromRemote, defaultBranch);
 
-  core.info(`These is a final list of branches action will operate on: ${JSON.stringify(filteredBranches, null, 2)}`);
+  core.info(`This is a final list of branches action will operate on: ${JSON.stringify(filteredBranches, null, 2)}`);
 
-  return [ filteredBranches, branchesFromRemote];
+  return [filteredBranches, branchesFromRemote];
 }
 
 /**


### PR DESCRIPTION
### New option

`bot_branch_name`

### Feature description

Use it if you do not want this action to create a new branch and new pull request with every run. By default branch names are generated. This means every single change is a separate commit. Such a static hardcoded branch name has an advantage that if you make a lot of changes, instead of having 5 PRs merged with 5 commits, you get one PR that is updated with new changes as long as the PR is not yet merged. If you use static name, and by mistake someone closed a PR, without merging and removing branch, this action will not fail but update the branch and open a new PR. Example value that you could provide: `bot_branch_name: bot/update-files-from-global-repo`.

Resolves #24